### PR TITLE
Fix for issue #4. Added "iframe-action.coffee" to files in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,30 @@ As part of rules you can use the following action:
 
 * load my_iframe with "http://www.pimatic.org"
 
+Troubleshooting
+-------------
+
+If the iframe content is not displayed the reason maybe one of the following *security restrictions*:
+
+* Pimatic web page has been loaded via https while iframe source is http. This will give you an error message on the
+  web console as shown below. *Workaround:* Either load pimatic page via http or load iframe src via https (if https
+  is supported by the site).
+
+    ```
+    Mixed Content: The page at 'https://localhost/' was loaded over HTTPS, but requested an insecure
+    resource 'http://www.pimatic.org'. This request has been blocked; the content must be served over HTTPS.
+    ```
+
+* Sourced web site denies embedding. This is the case with google.com, for example. Workaround: Some sites offer
+  additional resources which can be embedded, for example, this is the case
+  for [googlemaps](https://developers.google.com/maps/documentation/embed/guide). Otherwise, you can only
+  circumvent the restriction by putting a rewriting http proxy into the communication path.
+
+    ```
+    Refused to display 'https://www.google.de/?gfe_rd=cr&ei=7wgIVuiXCY6r8wfYkLnoDQ&gws_rd=ssl'
+    in a frame because it set 'X-Frame-Options' to 'SAMEORIGIN'.
+    ```
+
 Version History
 ---------------
     0.0.1 : Initial release

--- a/app/iframe-page.coffee
+++ b/app/iframe-page.coffee
@@ -7,28 +7,62 @@ $(document).on( "templateinit", (event) ->
 			@frameId = @device.id + "_iframe"
 			@name = @device.name
 			@url = @device.config.url
-			@width = @device.config.width  ? @device.configDefaults.width
+			@width = @device.config.width ? @device.configDefaults.width
 			@height = @device.config.height ? @device.configDefaults.height
 			@border = @device.config.border ? @device.configDefaults.border
 			@scrolling = @device.config.scrolling ? @device.configDefaults.scrolling
+			@overflow = ko.observable(if @scrolling is 'no' then 'hidden' else 'auto')
 			@scale = @device.config.scale ? @device.configDefaults.scale
-			@divWidth = Math.round(@width * @scale) + @border
-			@divHeight = Math.round(@height * @scale) + @border
-			super(templData,@device)
-
+			@divWidth = Math.round(@width * @scale) + (2 * @border)
+			@divHeight = Math.round(@height * @scale) + (2 * @border)
 			@reload = @device.config.reload  ? @device.configDefaults.reload
-			if @reload > 0
-				setInterval ( =>
-					frame = document.getElementById @frameId
-					frame.src = frame.src if frame?
-				), @reload * 1000
+			super(templData,@device)
 
 			attribute = @getAttribute("url")
 			@url = ko.observable attribute.value()
 			attribute.value.subscribe (newValue) =>
 				@url newValue
-				el.val(@url()).trigger 'change', [origin: 'remote']
 
-  # register the item-class
+		afterRender: (elements) ->
+			super(elements)
+			timeout = null
+
+			resize = =>
+				frame = document.getElementById @frameId
+#				console.log(
+#					$(frame).parent().parent().width(),
+#					$(frame).parent().parent().get(0).getBoundingClientRect().width,
+#					$(frame).parent().width(),
+#					$(frame).parent().get(0).getBoundingClientRect().width,
+#					$(frame).width(),
+#					$(frame).get(0).getBoundingClientRect().width
+#				)
+				if (frame? and $(frame).parent().width() >= $(frame).get(0).getBoundingClientRect().width)
+					@overflow 'hidden'
+				else if @scrolling isnt 'no'
+					@overflow 'auto'
+
+			resize()
+			# When "resize" is triggered the resize may be still in progress. Thus, the resize function call will be
+			# deferred to get proper results for the width of the parent elements. This is also a strategy to
+			# de-bounce the resize event as it may be fire multiple times in a row
+			# See http://stackoverflow.com/a/5490021/4816693
+			window.onresize = =>
+				if timeout?
+					clearTimeout timeout
+					timeout = null
+				timeout = setTimeout resize, 750
+
+
+			# Reload the iframe source periodically if "reload" device property has been set to a value > 0
+			# See http://stackoverflow.com/a/4062084/4816693			if @reload > 0
+			setInterval ( =>
+				frame = document.getElementById @frameId
+				frame.src = frame.src if frame?
+			), @reload * 1000
+
+
+
+	# register the item-class
 	pimatic.templateClasses['iframe'] = iframeDeviceItem
 )

--- a/app/iframe-template.html
+++ b/app/iframe-template.html
@@ -1,26 +1,36 @@
 <script id="iframe-template" type="text/template">
     <li data-bind="attr: { id: id }" class="sortable no-header">
         <div>
-            <label class="device-label" data-bind="text: name" />
+            <label class="device-label" data-bind="text: name"/>
         </div>
         <div data-bind="style:{
-                            padding: '0',
-                            overflow: 'hidden',
-                            height: '' + divHeight + 'px'
+                            padding: '0px',
+                            height: divHeight + 'px',
+                            overflowX: overflow,
+                            overflowY: 'hidden'
                         }">
             <iframe data-bind="attr:{
                                     src: url,
-                                    width: width,
-                                    height: height,
+                                    marginwidth: 0 + 'px',
+                                    marginheight: 0 + 'px',
                                     id: frameId,
-                                    scrolling: scrolling,
-                                    overflow: 'hidden'},
+                                    scrolling: scrolling
+                                },
                                 style:{
-                                    border: '0',
+                                    width: width + 'px',
+                                    height: height + 'px',
+                                    border: border + 'px solid black',
                                     transform: 'scale(' + scale + ')',
-                                    mozTransform: 'scale(' + scale + ')',
+                                    webkitTransform: 'scale(' + scale + ')',
+                                    msTransform: 'scale(' + scale + ')',
+                                    oTransform: 'scale(' + scale + ')',
+                                    MozTransform: 'scale(' + scale + ')',
                                     transformOrigin: '0 0',
-                                    mozTransformOrigin: '0 0'}"/>
+                                    webkitTransformOrigin: '0 0',
+                                    msTransformOrigin: '0 0',
+                                    oTransformOrigin: '0 0',
+                                    MozTransformOrigin: '0 0'
+                                }"/>
         </div>
     </li>
 </script>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "iframe",
     "files": [
         "iframe.coffee",
+        "iframe-action.coffee",
         "README.md",
         "device-config-schema.coffee",
         "iframe-config-schema.coffee",


### PR DESCRIPTION
Fixed border drawing
Added marginwidth and marginheight to reset margin for embedded document as Firefox adds 4px by default
Added browser-specific transform properties
Improved horizontal scroll-behaviour of the iframe container. Now it adapts to the actual width of the parent.
