### PR TITLE
refreshHack to create an unique URL for each update of the iframe.src. This can be used if the content of the target is cached by the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Add the plugin to the plugin section:
 Configuration
 -------------
 
-You have to add a iframe Device device into your config.json based on these example schema ready to copy paste.
+You have to add a iframe Device device into your config.json based on these example schema ready to copy paste. 
+Please have a look at the Trouble Shooting section below if the content isn't displayed or reloaded properly.
 
     {
       "class": "iframeDevice",
@@ -27,7 +28,8 @@ You have to add a iframe Device device into your config.json based on these exam
       "border": 1,
       "scrolling": "yes",
       "scale": 1,
-      "reload": 0
+      "reload": 0,
+      "enforceReload": false
     },
 
 Description:
@@ -42,8 +44,9 @@ Description:
     height : Height of iframe
     border : Show border around iframe (1 = yes, 0 = no)
     scrolling : Show scrollbars in iframe (yes/no)
-    scale : scaling factor of iframe content
+    scale : Scaling factor of iframe content
     reload : Reload cycle in seconds for iframe source. 0 = no reload
+    enforceReload : Add a pseudo URL param to make URL unique. This is to solve browser-caching issues
 
 Load Action:
 -------------
@@ -79,6 +82,20 @@ If the iframe content is not displayed the reason maybe one of the following *se
     Refused to display 'https://www.google.de/?gfe_rd=cr&ei=7wgIVuiXCY6r8wfYkLnoDQ&gws_rd=ssl'
     in a frame because it set 'X-Frame-Options' to 'SAMEORIGIN'.
     ```
+    
+If the iframe content is not properly reloaded or updated this may be due to browser-caching issues:
+
+* Normally, the browser avoids reloading web content from the server by serving web resources from its local 
+  cache to speed up web browsing, significantly. To facilitate caching, the HTTP protocol includes various 
+  mechanisms to support the browser in determining the lifetime of a (cached) web resource and to let the browser 
+  querying the server if a given web resource has been changed. This works very well most of the time, but 
+  there are cases where web servers have been misconfigured or the server implementation does not support 
+  cache-control. As a result the iframe content may not be reloaded properly as it will always be served from the 
+  browser-cache rather than requesting the (updated) content from the server. In particular, this has been found 
+  to be case with some IP web camera applications where the web content typically is an image file being continuously 
+  updated by the server. In such cases you can set `enforceReload` property to `true`.  This will add a query 
+  parameter with a timestamp for each reload cycle to make the requested URL unique. As a result the browser will 
+  regard the given URL as a new resource and bypass the cache.
 
 Version History
 ---------------

--- a/app/iframe-page.coffee
+++ b/app/iframe-page.coffee
@@ -25,13 +25,13 @@ $(document).on( "templateinit", (event) ->
 
 		# coffeescript version of https://gist.github.com/niyazpk/f8ac616f181f6042d1e0
 		updateUrlParameter: (uri, key, value) ->
-			i = uri.indexOf '#'
+			i = uri.indexOf('#')
 			hash = if i is -1 then ''  else uri.substr(i)
 			uri = if i is -1 then uri else uri.substr(0, i)
 
-			re = new RegExp '([?&])' + key + '=.*?(&|$)', 'i'
+			re = new RegExp('([?&])' + key + '=.*?(&|$)', 'i')
 			separator = if uri.indexOf('?') isnt -1 then '&' else '?'
-			if (uri.match(re))
+			if uri.match(re)
 				uri = uri.replace(re, '$1' + key + '=' + value + '$2')
 			else
 				uri = uri + separator + key + '=' + value;
@@ -74,7 +74,7 @@ $(document).on( "templateinit", (event) ->
 				setInterval ( =>
 					frame = document.getElementById @frameId
 					if frame?
-						if @device.config.refreshHack  ? @device.configDefaults.refreshHack
+						if @device.config.enforceReload  ? @device.configDefaults.enforceReload
 							frame.src = @updateUrlParameter frame.src, '__refresh', Date.now()
 						else
 							frame.src = frame.src

--- a/app/iframe-page.coffee
+++ b/app/iframe-page.coffee
@@ -75,9 +75,9 @@ $(document).on( "templateinit", (event) ->
 					frame = document.getElementById @frameId
 					if frame?
 						if @device.config.refreshHack  ? @device.configDefaults.refreshHack
-							frame.src = @updateUrlParameter @device.config.url, '__refresh', Date.now()
+							frame.src = @updateUrlParameter frame.src, '__refresh', Date.now()
 						else
-							frame.src = @device.config.url
+							frame.src = frame.src
 				), @reload * 1000
 
 

--- a/app/iframe-page.coffee
+++ b/app/iframe-page.coffee
@@ -23,6 +23,20 @@ $(document).on( "templateinit", (event) ->
 			attribute.value.subscribe (newValue) =>
 				@url newValue
 
+		# coffeescript version of https://gist.github.com/niyazpk/f8ac616f181f6042d1e0
+		updateUrlParameter: (uri, key, value) ->
+			i = uri.indexOf '#'
+			hash = if i is -1 then ''  else uri.substr(i)
+			uri = if i is -1 then uri else uri.substr(0, i)
+
+			re = new RegExp '([?&])' + key + '=.*?(&|$)', 'i'
+			separator = if uri.indexOf('?') isnt -1 then '&' else '?'
+			if (uri.match(re))
+				uri = uri.replace(re, '$1' + key + '=' + value + '$2')
+			else
+				uri = uri + separator + key + '=' + value;
+			return uri + hash
+
 		afterRender: (elements) ->
 			super(elements)
 			timeout = null
@@ -59,7 +73,11 @@ $(document).on( "templateinit", (event) ->
 			if @reload > 0
 				setInterval ( =>
 					frame = document.getElementById @frameId
-					frame.src = frame.src if frame?
+					if frame?
+						if @device.config.refreshHack  ? @device.configDefaults.refreshHack
+							frame.src = @updateUrlParameter @device.config.url, '__refresh', Date.now()
+						else
+							frame.src = @device.config.url
 				), @reload * 1000
 
 

--- a/app/iframe-template.html
+++ b/app/iframe-template.html
@@ -1,7 +1,7 @@
 <script id="iframe-template" type="text/template">
     <li data-bind="attr: { id: id }" class="sortable no-header">
         <div>
-            <label class="device-label" data-bind="text: name"/>
+            <label class="device-label" data-bind="text: name, tooltip: $data.labelTooltipHtml"></label>
         </div>
         <div data-bind="style:{
                             padding: '0px',
@@ -30,7 +30,7 @@
                                     msTransformOrigin: '0 0',
                                     oTransformOrigin: '0 0',
                                     MozTransformOrigin: '0 0'
-                                }"/>
+                                }"></iframe>
         </div>
     </li>
 </script>

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -33,8 +33,8 @@ module.exports = {
 				description: "Reload cycle in seconds for iframe source. 0 = no reload"
 				type: "number"
 				default : 0
-			refreshHack:
-				description: "Add a __refresh URL param to make URL unique. This is to solve caching issues"
+			enforceReload:
+				description: "Add a pseudo URL param to make URL unique. This is to solve browser-caching issues"
 				type: "boolean"
 				default: false
 	}

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -33,5 +33,9 @@ module.exports = {
 				description: "Reload cycle in seconds for iframe source. 0 = no reload"
 				type: "number"
 				default : 0
+			refreshHack:
+				description: "Add a _refresh URL param to make URL unique. This is to solve caching issues"
+				type: "boolean"
+				default: false
 	}
 }

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -34,7 +34,7 @@ module.exports = {
 				type: "number"
 				default : 0
 			refreshHack:
-				description: "Add a _refresh URL param to make URL unique. This is to solve caching issues"
+				description: "Add a __refresh URL param to make URL unique. This is to solve caching issues"
 				type: "boolean"
 				default: false
 	}

--- a/iframe.coffee
+++ b/iframe.coffee
@@ -60,12 +60,16 @@ module.exports = (env) ->
 				description: "Reload cycle in seconds for iframe source. 0 = no reload"
 				type: "number"
 				default : 0
+			refreshHack:
+				description: "Add a _refresh URL param to make URL unique. This is to solve caching issues"
+				type: "boolean"
+				default: false
 		actions:
 			loadIFrameWith:
 				description: 'loads the iframe with a new source URL'
 		template: 'iframe'
 
-		constructor: (@config,@plugin) ->
+		constructor: (@config, @plugin) ->
 			@id = @config.id
 			@name = @config.name
 			@url = @config.url
@@ -75,6 +79,11 @@ module.exports = (env) ->
 			@scrolling = @config.scrolling
 			@scale = @config.scale
 			@reload = @config.reload
+			@refreshHack = @config.refreshHack
+			super()
+
+		destroy: ()  ->
+			@reload = 0
 			super()
 
 		loadIFrameWith: (url) ->
@@ -90,6 +99,7 @@ module.exports = (env) ->
 		getScrolling: -> Promise.resolve(@scrolling)
 		getScale: -> Promise.resolve(@scale)
 		getReload: -> Promise.resolve(@reload)
+		getRefreshHack: -> Promise.resolve(@refreshHack)
 
 
 	myPlugin = new iframePlugin

--- a/iframe.coffee
+++ b/iframe.coffee
@@ -60,8 +60,8 @@ module.exports = (env) ->
 				description: "Reload cycle in seconds for iframe source. 0 = no reload"
 				type: "number"
 				default : 0
-			refreshHack:
-				description: "Add a _refresh URL param to make URL unique. This is to solve caching issues"
+			enforceReload:
+				description: "Add a pseudo URL parameter to make URL unique. This is to solve browser-caching issues"
 				type: "boolean"
 				default: false
 		actions:
@@ -79,7 +79,7 @@ module.exports = (env) ->
 			@scrolling = @config.scrolling
 			@scale = @config.scale
 			@reload = @config.reload
-			@refreshHack = @config.refreshHack
+			@enforceReload = @config.enforceReload
 			super()
 
 		destroy: ()  ->
@@ -99,7 +99,7 @@ module.exports = (env) ->
 		getScrolling: -> Promise.resolve(@scrolling)
 		getScale: -> Promise.resolve(@scale)
 		getReload: -> Promise.resolve(@reload)
-		getRefreshHack: -> Promise.resolve(@refreshHack)
+		getEnforceReload: -> Promise.resolve(@enforceReload)
 
 
 	myPlugin = new iframePlugin


### PR DESCRIPTION
- Added refreshHack to create an unique URL for each update of the iframe.src. This can be used if the content of the target is cached by the browser, issue #8 
- Added tooltip binding for label to be able to edit the iframe device using the "Edit Device" link
- Added destory function
